### PR TITLE
Fix reference to "request_ip" in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ We first need to construct a plug that will list various rules we want to apply:
 ```elixir
 defmodule MyApp.PlugAttack do
   use PlugAttack
-  
+
   rule "allow local", conn do
     allow conn.remote_ip == {127, 0, 0, 1}
   end
@@ -63,7 +63,7 @@ ip address:
 
 ```elixir
 rule "throttle by ip", conn do
-  throttle conn.request_ip,
+  throttle conn.remote_ip,
     period: 60_000, limit: 10,
     storage: {PlugAttack.Storage.Ets, MyApp.PlugAttack.Storage}
 end


### PR DESCRIPTION
Hey @michalmuskala , really appreciate this library. Quick fix to the readme here.

Also, might make an issue later... still trying to figure out if I'm doing something wrong.

This is the error I'm experiencing currently:
```
** (ArgumentError) argument error
        (stdlib) :ets.update_counter(MyApp.PlugAttack.Storage, {:throttle, {127, 0, 0, 1}, 12327780}, 1, {{:throttle, {127, 0, 0, 1}, 12327780}, 0, 1479333720000})
        (plug_attack) lib/storage/ets.ex:27: PlugAttack.Storage.Ets.increment/4
        (plug_attack) lib/rule.ex:80: PlugAttack.Rule.do_throttle/2

```
^ Where MyApp is the application running PlugAttack. Let me know if anything jumps out at you.

Thanks!