### PR TITLE
Minor documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 
   1. Add `plug_attack` to your list of dependencies in `mix.exs`:
 
-    ```elixir
-    def deps do
-      [{:plug_attack, "~> 0.3.0"}]
-    end
-    ```
+```elixir
+def deps do
+  [{:plug_attack, "~> 0.3.0"}]
+end
+```
 
   2. If using Elixir 1.3, ensure that `plug_attack` is started before your application  
   (this step is no longer applicable to Elixir 1.4+):
 
-    ```elixir
-    def application do
-      [applications: [:plug_attack]]
-    end
-    ```
+```elixir
+def application do
+  [applications: [:plug_attack]]
+end
+```
 
 ## Basic usage
 

--- a/lib/plug_attack.ex
+++ b/lib/plug_attack.ex
@@ -12,6 +12,7 @@ defmodule PlugAttack do
   ## Example
 
       defmodule MyApp.PlugAttack do
+        import Plug.Conn
         use PlugAttack
 
         # For more rules examples see PlugAttack.rule/2 macro documentation.


### PR DESCRIPTION
There were a couple of nits in the README.md which meant that the ```elixir syntax highlighting didn't work for a couple of code examples.

The addition of Plug.Conn in 3dfebb1 wasn't included in the @moduledoc