### PR TITLE
Change atom name in module documentation

### DIFF
--- a/lib/storage/ets.ex
+++ b/lib/storage/ets.ex
@@ -12,7 +12,7 @@ defmodule PlugAttack.Storage.Ets do
       ]
 
   This will later allow you to pass the `:storage` option to various rules
-  as `storage: {PlugAttack.Ets, MyApp.PlugAttackStorage}`
+  as `storage: {PlugAttack.Storage.Ets, MyApp.PlugAttackStorage}`
 
   """
 


### PR DESCRIPTION
The first element in the tuple that is passed as the value for the `storage` option should be the name of a chosen implementation module.

In the example that the documentation outline, the atom name should be the same as the module the documentation resides in.
