### PR TITLE
Fix static :block response in fail2ban rule

### DIFF
--- a/lib/rule.ex
+++ b/lib/rule.ex
@@ -146,6 +146,6 @@ defmodule PlugAttack.Rule do
     if mod.read_sliding_counter(opts, {:fail2ban, key}, now) >= limit do
       mod.write(opts, {:fail2ban_banned, key}, true, now + ban_for)
     end
-    {:block, {:fail2ban, :counting, key}}
+    {:allow, {:fail2ban, :counting, key}}
   end
 end

--- a/test/rules_test.exs
+++ b/test/rules_test.exs
@@ -7,20 +7,20 @@ defmodule PlugAttack.RuleTest do
   end
 
   test "fail2ban" do
-    assert {:block, {:fail2ban, :counting, :key}} = fail2ban()
+    assert {:allow, {:fail2ban, :counting, :key}} = fail2ban()
     :timer.sleep(1)
-    assert {:block, {:fail2ban, :counting, :key}} = fail2ban()
+    assert {:allow, {:fail2ban, :counting, :key}} = fail2ban()
     :timer.sleep(150)
 
-    assert {:block, {:fail2ban, :counting, :key}} = fail2ban()
+    assert {:allow, {:fail2ban, :counting, :key}} = fail2ban()
     :timer.sleep(1)
-    assert {:block, {:fail2ban, :counting, :key}} = fail2ban()
+    assert {:allow, {:fail2ban, :counting, :key}} = fail2ban()
     :timer.sleep(1)
-    assert {:block, {:fail2ban, :counting, :key}} = fail2ban()
+    assert {:allow, {:fail2ban, :counting, :key}} = fail2ban()
     :timer.sleep(100)
     assert {:block, {:fail2ban, :banned, :key}} = fail2ban()
     :timer.sleep(200)
-    assert {:block, {:fail2ban, :counting, :key}} = fail2ban()
+    assert {:allow, {:fail2ban, :counting, :key}} = fail2ban()
   end
 
   defp fail2ban() do


### PR DESCRIPTION
It appears as `PlugAttack.Rule.fail2ban/2` implementation accidentally blocked all requests. This should fix it.