### PR TITLE
Update/modernize readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,11 @@ This is inspired by the Kickstarter's Rack::Attack middleware for Ruby.
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
-
-  1. Add `plug_attack` to your list of dependencies in `mix.exs`:
+  Add `plug_attack` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:plug_attack, "~> 0.4.2"}]
-end
-```
-
-  2. If using Elixir 1.3, ensure that `plug_attack` is started before your application  
-  (this step is no longer applicable to Elixir 1.4+):
-
-```elixir
-def application do
-  [applications: [:plug_attack]]
+  [{:plug_attack, "~> 0.4.3"}]
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,6 @@ supervision tree:
 
 ```elixir
 children = [
-  # other children
-  worker(PlugAttack.Storage.Ets, [MyApp.PlugAttack.Storage, [clean_period: 60_000]])
-]
-
-# or using child specifications:
-
-children = [
   {PlugAttack.Storage.Ets, name: MyApp.PlugAttack.Storage, clean_period: 60_000}
 ]
 ```


### PR DESCRIPTION
Remove note about usage with Elixir 1.3 (1.4 was released in 2017 and I highly doubt many people are still using it)

Also remove the "If available in Hex" line since this library is available in Hex

Remove the deprecated worker specification for adding `PlugAttack.Storage.Ets` to the supervision tree